### PR TITLE
Fixed query method support for BETWEEN and IN filters

### DIFF
--- a/lib/ddb.js
+++ b/lib/ddb.js
@@ -759,20 +759,32 @@ var ddb = function(spec, my)
       }
       data.TableName = table;
 
-      if (options.queryFilter)
-      {
-        var nFilter = {};
-        for (var i in options.filter.keys)
-        {
-          if (options.filter.keys.hasOwnProperty(i))
-          {
-            nFilter[i] = {
-              ComparisonOperator: options.filter.operators[i],
-              AttributeValueList: [scToDDB(options.filter.keys[i])]
+      if(options.filter) {
+          var filter = options.filter,
+            queryFilter = {},
+            operator,
+            value;
+
+          for(var attr in filter.keys) {
+              operator = filter.operators[attr].toUpperCase(),
+                value = filter.keys[attr];
+
+              queryFilter[attr] = {
+                 ComparisonOperator: operator,
+                 AttributeValueList: []
+             };
+
+            if(filter.keys.hasOwnProperty(attr)) {
+                if((operator === 'BETWEEN' || operator === 'IN') && Array.isArray(value) && value.length > 1){
+                    for(var i = 0; i < value.length; i++){
+                        queryFilter[attr].AttributeValueList.push(scToDDB(value[i]));
+                    }
+                } else {
+                  queryFilter[attr].AttributeValueList.push(scToDDB(value));
+                }
             }
-          }
         }
-        data.QueryFilter = nFilter;
+        data.QueryFilter = queryFilter;
       }
 
       if (options.filterExpression)


### PR DESCRIPTION
The current implementation of the `query` method breaks for **BETWEEN** operators, with a message in the lines of:

> One or more parameter values were invalid: Invalid number of argument(s) for the BETWEEN ComparisonOperator

This PR provides a sample implementation that supports **BETWEEN** operators. No tests provided. 

``` js
var filter = {
        queryFilter:true,
        filter: {
            keys: {
                time: [500, 600]
            },
            operators: {
                time: 'BETWEEN'
            }
        }
    };

    _ddb.query(config.tableName, {transmitter_id: '12DFG-H34-BH3UQ'}, {transmitter_id: 'EQ'}, filter, function(err, res, cap){
        if(err) return console.error('DB query', err);
        console.log('getItem done: CAP %s RESP %s', cap, JSON.stringify(res, null, 4));
    });
```
